### PR TITLE
TF timestamp Problem

### DIFF
--- a/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/include/slam_toolbox/slam_toolbox_common.hpp
@@ -143,6 +143,7 @@ protected:
   // Storage for ROS parameters
   std::string odom_frame_, map_frame_, base_frame_, map_name_, scan_topic_;
   bool use_map_saver_;
+  bool publish_map_once_, update_map_once_;
   rclcpp::Duration transform_timeout_, minimum_time_interval_;
   std_msgs::msg::Header scan_header;
   int throttle_scans_, scan_queue_size_;

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -287,10 +287,20 @@ void SlamToolbox::publishVisualizations()
   double map_update_interval = 10;
   map_update_interval = this->declare_parameter("map_update_interval",
       map_update_interval);
+  publish_map_once_ = this->declare_parameter("publish_map_once",
+      publish_map_once_);
   rclcpp::Rate r(1.0 / map_update_interval);
 
   while (rclcpp::ok()) {
-    updateMap();
+    if(publish_map_once_){
+      if(update_map_once_){
+        updateMap();
+        update_map_once_ = false;
+      }
+    }
+    else{
+      updateMap();
+    }
     if (!isPaused(VISUALIZING_GRAPH)) {
       boost::mutex::scoped_lock lock(smapper_mutex_);
       closure_assistant_->publishGraph();


### PR DESCRIPTION
added use_map_update_once param. This param solves the problem of visualization publishing of the map. While this mode is false its usable for mapping, when its true its usable for localization.

If we do net use the true setting, From [the publishVisualizations loop](https://github.com/techtilesg/slam_toolbox/blob/ee00cf7cab882b4484ccd9fa18413e237b1bccfa/slam_toolbox/src/slam_toolbox_common.cpp#L320C18-L320C18), it will lock the [main scan processing loop](https://github.com/techtilesg/slam_toolbox/blob/ee00cf7cab882b4484ccd9fa18413e237b1bccfa/slam_toolbox/src/slam_toolbox_localization.cpp#L150C43-L150C43)