### PR TITLE
Humble localization health

### DIFF
--- a/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/include/slam_toolbox/slam_toolbox_common.hpp
@@ -49,6 +49,8 @@
 #include "slam_toolbox/map_saver.hpp"
 #include "slam_toolbox/loop_closure_assistant.hpp"
 
+#include <std_msgs/msg/float32.hpp> // TODO: change here idk
+
 namespace slam_toolbox
 {
 
@@ -135,6 +137,7 @@ protected:
   std::shared_ptr<rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>> sst_;
   std::shared_ptr<rclcpp::Publisher<nav_msgs::msg::MapMetaData>> sstm_;
   std::shared_ptr<rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>> pose_pub_;
+  std::shared_ptr<rclcpp::Publisher<std_msgs::msg::Float32>> localization_health_pub_; // TODO: Change here
   std::shared_ptr<rclcpp::Service<nav_msgs::srv::GetMap>> ssMap_;
   std::shared_ptr<rclcpp::Service<slam_toolbox::srv::Pause>> ssPauseMeasurements_;
   std::shared_ptr<rclcpp::Service<slam_toolbox::srv::SerializePoseGraph>> ssSerialize_;

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -1961,6 +1961,14 @@ public:
   virtual ~Mapper();
 
 public:
+
+  /** 
+   * Purpose of this function is set the best response to localization health information
+   */
+  double * m_pbestResponse;
+  double * GetBestResponse();
+  void  SetBestResponse(double * pBestResponse);
+
   /**
    * Allocate memory needed for mapping
    * @param rangeThreshold

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -634,6 +634,19 @@ kt_double ScanMatcher::MatchScan(
     rCovariance(0, 0) << ", " << rCovariance(1, 1) << std::endl;
 #endif
   assert(math::InRange(rMean.GetHeading(), -KT_PI, KT_PI));
+  /*
+  * purpose of equal to best_response is; Instead of {double} type {kt_double} doesn't mean anything inside the slam_toolbox_common 
+  */
+  double best_response = bestResponse; 
+
+  try
+  {
+    m_pMapper->SetBestResponse(&best_response);  
+  }
+  catch (std::exception & e) {
+    throw std::runtime_error("LOCALIZATIONHEALTH PUBLISHER FATAL ERROR - "
+            "unable to publish set best response!");
+  }
 
   return bestResponse;
 }

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -3239,6 +3239,18 @@ void Mapper::FireEndLoopClosure(const std::string & rInfo) const
   }
 }
 
+double* Mapper::GetBestResponse()
+{
+  return m_pbestResponse; 
+}
+
+void Mapper::SetBestResponse(double* pBestResponse)
+{
+  if (pBestResponse != nullptr) {
+    *m_pbestResponse = *pBestResponse; 
+  }
+}
+
 void Mapper::SetScanSolver(ScanSolver * pScanOptimizer)
 {
   m_pScanOptimizer = pScanOptimizer;

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -2055,7 +2055,8 @@ Mapper::Mapper()
   m_pSequentialScanMatcher(NULL),
   m_pMapperSensorManager(NULL),
   m_pGraph(NULL),
-  m_pScanOptimizer(NULL)
+  m_pScanOptimizer(NULL),
+  m_pbestResponse(new double(0.0))
 {
   InitializeParameters();
 }
@@ -2070,7 +2071,8 @@ Mapper::Mapper(const std::string & rName)
   m_pSequentialScanMatcher(NULL),
   m_pMapperSensorManager(NULL),
   m_pGraph(NULL),
-  m_pScanOptimizer(NULL)
+  m_pScanOptimizer(NULL),
+  m_pbestResponse(new double(0.0))
 {
   InitializeParameters();
 }
@@ -2663,6 +2665,10 @@ void Mapper::Reset()
   if (m_pMapperSensorManager) {
     delete m_pMapperSensorManager;
     m_pMapperSensorManager = NULL;
+  }
+  if (m_pbestResponse) {
+    delete m_pbestResponse;
+    m_pbestResponse = NULL;
   }
   m_Initialized = false;
   m_Deserialized = false;

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -255,6 +255,18 @@ void SlamToolbox::publishTransformLoop(
     {
       boost::mutex::scoped_lock lock(map_to_odom_mutex_);
       rclcpp::Time scan_timestamp = scan_header.stamp;
+
+      //TODO: In future, we need to remove from there and create new function named as localizationHealthCheck.
+      double * best_response =smapper_->getMapper()->GetBestResponse();
+      if (best_response != nullptr && *best_response > 0.02) {
+          try {
+          //TODO: Write publisher topic for localization health check.
+          } catch (std::exception & e) {
+          //TODO: Write publisher topic when cannot acces the result of health check .
+          }
+      } 
+      //      
+
       // Avoid publishing tf with initial 0.0 scan timestamp
       if (scan_timestamp.seconds() > 0.0 && !scan_header.frame_id.empty()) {
         geometry_msgs::msg::TransformStamped msg;

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -209,7 +209,7 @@ void SlamToolbox::setROSInterfaces()
   pose_pub_ = this->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
     "pose", 10);
   localization_health_pub_ = this->create_publisher<std_msgs::msg::Float32>(
-    "localization_health_baha", 10);
+    "slam_toolbox/best_response", 10);
 
   sst_ = this->create_publisher<nav_msgs::msg::OccupancyGrid>(
     map_name_, rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());


### PR DESCRIPTION

# EXPLANATION 
localization health mode and more debug parameters has been added. you can access the data with listening: `/<namespace>/slam_toolbox/best_response`

# Debugging
For debug bestResponse and cost times of calculation  you can uncomment [this](https://github.com/Renbago/slam_toolbox/blob/986e0472211db00d3758f0932f3b0a83b86daa89/lib/karto_sdk/src/Mapper.cpp#L50C1-L50C23)

# Coming SOON

> For now we are accessing the bestResponse inside of this(because by this way its more simple) [function](https://github.com/Renbago/slam_toolbox/blob/986e0472211db00d3758f0932f3b0a83b86daa89/src/slam_toolbox_common.cpp#L248C1-L248C40) in future its need to be change. 

> Inside from Karto more outputs for localizationHealth will be published as a topic. So new message type should be writed.
