### PR TITLE
Humble table mode ceres.2.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   srvs/AddSubmap.srv
   srvs/DeserializePoseGraph.srv
   srvs/DesiredPoseChecker.srv
+  srvs/ElevatorMode.srv
   srvs/SerializePoseGraph.srv
   DEPENDENCIES builtin_interfaces geometry_msgs std_msgs nav_msgs visualization_msgs
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   srvs/DeserializePoseGraph.srv
   srvs/SerializePoseGraph.srv
   srvs/SetParametersService.srv
+  msgs/SavedTargetInfo.msg
+  msgs/SavedTargetInfoArray.msg
   DEPENDENCIES builtin_interfaces geometry_msgs std_msgs nav_msgs visualization_msgs
 )
 

--- a/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/include/slam_toolbox/slam_toolbox_common.hpp
@@ -138,6 +138,7 @@ protected:
   std::shared_ptr<rclcpp::Publisher<nav_msgs::msg::MapMetaData>> sstm_;
   std::shared_ptr<rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>> pose_pub_;
   std::shared_ptr<rclcpp::Publisher<std_msgs::msg::Float32>> localization_health_pub_; // TODO: Change here
+  std::shared_ptr<rclcpp::Publisher<slam_toolbox::msg::SavedTargetInfoArray>> ssSaved_target_data_;
   std::shared_ptr<rclcpp::Service<nav_msgs::srv::GetMap>> ssMap_;
   std::shared_ptr<rclcpp::Service<slam_toolbox::srv::Pause>> ssPauseMeasurements_;
   std::shared_ptr<rclcpp::Service<slam_toolbox::srv::SerializePoseGraph>> ssSerialize_;

--- a/include/slam_toolbox/slam_toolbox_localization.hpp
+++ b/include/slam_toolbox/slam_toolbox_localization.hpp
@@ -47,6 +47,10 @@ protected:
     const std::shared_ptr<slam_toolbox::srv::DesiredPoseChecker::Request> req,
     std::shared_ptr<slam_toolbox::srv::DesiredPoseChecker::Response> res); 
 
+  bool elevatorMode(
+    const std::shared_ptr<slam_toolbox::srv::ElevatorMode::Request> req,
+    std::shared_ptr<slam_toolbox::srv::ElevatorMode::Response> res);
+
   virtual bool serializePoseGraphCallback(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<slam_toolbox::srv::SerializePoseGraph::Request> req,
@@ -61,6 +65,9 @@ protected:
     const sensor_msgs::msg::LaserScan::ConstSharedPtr & scan,
     Pose2 & pose) override;
 
+  void setInitialParametersElevatorMode(
+    double position_search_maximum_distance, double position_search_distance);
+
   void setInitialParametersForDesiredPose(
     double position_search_distance, double position_search_maximum_distance,
     double position_search_fine_angle_offset, double position_search_coarse_angle_offset,
@@ -71,6 +78,7 @@ protected:
   localization_pose_sub_;
   std::shared_ptr<rclcpp::Service<std_srvs::srv::Empty>> clear_localization_;
   std::shared_ptr<rclcpp::Service<slam_toolbox::srv::DesiredPoseChecker>> ssGetBestResponse_; // TODO: check here
+  std::shared_ptr<rclcpp::Service<slam_toolbox::srv::ElevatorMode>> ssGetElevatorMode_;
 
   sensor_msgs::msg::LaserScan::ConstSharedPtr last_scan_stored_;
   Pose2 last_odom_pose_stored_;

--- a/include/slam_toolbox/slam_toolbox_localization.hpp
+++ b/include/slam_toolbox/slam_toolbox_localization.hpp
@@ -67,6 +67,8 @@ protected:
     double position_search_smear_deviation, bool do_loop_closing_flag,
     int scan_buffer_size);
 
+  void triggerTableSave();
+
   std::shared_ptr<rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>>
   localization_pose_sub_;
 

--- a/include/slam_toolbox/slam_toolbox_localization.hpp
+++ b/include/slam_toolbox/slam_toolbox_localization.hpp
@@ -67,7 +67,6 @@ protected:
     double position_search_smear_deviation, bool do_loop_closing_flag,
     int scan_buffer_size);
 
-  void triggerTableSave();
   void getSavedTableData();
 
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_pub_;

--- a/include/slam_toolbox/slam_toolbox_localization.hpp
+++ b/include/slam_toolbox/slam_toolbox_localization.hpp
@@ -68,6 +68,11 @@ protected:
     int scan_buffer_size);
 
   void triggerTableSave();
+  void getSavedTableData();
+
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_pub_;
+  bool tableSaveComplete_ = false;
+
 
   std::shared_ptr<rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>>
   localization_pose_sub_;

--- a/include/slam_toolbox/toolbox_msgs.hpp
+++ b/include/slam_toolbox/toolbox_msgs.hpp
@@ -40,5 +40,6 @@
 #include "slam_toolbox/srv/merge_maps.hpp"
 #include "slam_toolbox/srv/add_submap.hpp"
 #include "slam_toolbox/srv/desired_pose_checker.hpp"
+#include "slam_toolbox/srv/elevator_mode.hpp"
 
 #endif  // SLAM_TOOLBOX__TOOLBOX_MSGS_HPP_

--- a/include/slam_toolbox/toolbox_msgs.hpp
+++ b/include/slam_toolbox/toolbox_msgs.hpp
@@ -29,6 +29,9 @@
 #include "visualization_msgs/msg/interactive_marker_control.hpp"
 #include "visualization_msgs/msg/interactive_marker_feedback.hpp"
 
+#include "slam_toolbox/msg/saved_target_info.hpp"
+#include "slam_toolbox/msg/saved_target_info_array.hpp"
+
 #include "slam_toolbox/srv/pause.hpp"
 #include "slam_toolbox/srv/clear_queue.hpp"
 #include "slam_toolbox/srv/toggle_interactive.hpp"

--- a/include/slam_toolbox/visualization_utils.hpp
+++ b/include/slam_toolbox/visualization_utils.hpp
@@ -149,7 +149,7 @@ inline visualization_msgs::msg::Marker toRectangleMarker(
   const double & width,
   const double & height,
   const double & scale,
-  const std::array<double, 4> & color,  
+  const std::array<double, 4> & color,  // RGBA array
   rclcpp::Node::SharedPtr node)
 {
   visualization_msgs::msg::Marker marker;
@@ -158,26 +158,53 @@ inline visualization_msgs::msg::Marker toRectangleMarker(
   marker.header.frame_id = frame;
   marker.header.stamp = node->now();
   marker.ns = ns;
-  marker.type = visualization_msgs::msg::Marker::SPHERE;
+  marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
   marker.action = visualization_msgs::msg::Marker::ADD;
+  marker.pose.orientation.w = 1.0;
 
-  // Set position
-  marker.pose.position.x = x;
-  marker.pose.position.y = y;
-  marker.pose.position.z = 0.0;
-  marker.pose.orientation.w = 1.0; // No rotation for a sphere
-
-  // Set scale
-  marker.scale.x = scale;
-  marker.scale.y = scale;
-  marker.scale.z = scale;
-
-  // Set color
+  marker.scale.x = scale;  // Line width
   marker.color.r = color[0];
   marker.color.g = color[1];
   marker.color.b = color[2];
   marker.color.a = color[3];
-  
+
+  // Calculate rectangle corners
+  double half_width = width / 2.0;
+  double half_height = height / 2.0;
+
+  double cos_yaw = cos(yaw);
+  double sin_yaw = sin(yaw);
+
+  std::vector<geometry_msgs::msg::Point> corners(5);
+
+  // Top-right corner
+  corners[0].x = x + (cos_yaw * half_width - sin_yaw * half_height);
+  corners[0].y = y + (sin_yaw * half_width + cos_yaw * half_height);
+  corners[0].z = 0.0;
+
+  // Top-left corner
+  corners[1].x = x + (cos_yaw * -half_width - sin_yaw * half_height);
+  corners[1].y = y + (sin_yaw * -half_width + cos_yaw * half_height);
+  corners[1].z = 0.0;
+
+  // Bottom-left corner
+  corners[2].x = x + (cos_yaw * -half_width - sin_yaw * -half_height);
+  corners[2].y = y + (sin_yaw * -half_width + cos_yaw * -half_height);
+  corners[2].z = 0.0;
+
+  // Bottom-right corner
+  corners[3].x = x + (cos_yaw * half_width - sin_yaw * -half_height);
+  corners[3].y = y + (sin_yaw * half_width + cos_yaw * -half_height);
+  corners[3].z = 0.0;
+
+  // Close the rectangle
+  corners[4] = corners[0];
+
+  // Add corners to the marker
+  for (const auto & corner : corners) {
+    marker.points.push_back(corner);
+  }
+
   return marker;
 }
 

--- a/include/slam_toolbox/visualization_utils.hpp
+++ b/include/slam_toolbox/visualization_utils.hpp
@@ -149,7 +149,7 @@ inline visualization_msgs::msg::Marker toRectangleMarker(
   const double & width,
   const double & height,
   const double & scale,
-  const std::array<double, 4> & color,  // RGBA array
+  const std::array<double, 4> & color,  
   rclcpp::Node::SharedPtr node)
 {
   visualization_msgs::msg::Marker marker;
@@ -158,53 +158,26 @@ inline visualization_msgs::msg::Marker toRectangleMarker(
   marker.header.frame_id = frame;
   marker.header.stamp = node->now();
   marker.ns = ns;
-  marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+  marker.type = visualization_msgs::msg::Marker::SPHERE;
   marker.action = visualization_msgs::msg::Marker::ADD;
-  marker.pose.orientation.w = 1.0;
 
-  marker.scale.x = scale;  // Line width
+  // Set position
+  marker.pose.position.x = x;
+  marker.pose.position.y = y;
+  marker.pose.position.z = 0.0;
+  marker.pose.orientation.w = 1.0; // No rotation for a sphere
+
+  // Set scale
+  marker.scale.x = scale;
+  marker.scale.y = scale;
+  marker.scale.z = scale;
+
+  // Set color
   marker.color.r = color[0];
   marker.color.g = color[1];
   marker.color.b = color[2];
   marker.color.a = color[3];
-
-  // Calculate rectangle corners
-  double half_width = width / 2.0;
-  double half_height = height / 2.0;
-
-  double cos_yaw = cos(yaw);
-  double sin_yaw = sin(yaw);
-
-  std::vector<geometry_msgs::msg::Point> corners(5);
-
-  // Top-right corner
-  corners[0].x = x + (cos_yaw * half_width - sin_yaw * half_height);
-  corners[0].y = y + (sin_yaw * half_width + cos_yaw * half_height);
-  corners[0].z = 0.0;
-
-  // Top-left corner
-  corners[1].x = x + (cos_yaw * -half_width - sin_yaw * half_height);
-  corners[1].y = y + (sin_yaw * -half_width + cos_yaw * half_height);
-  corners[1].z = 0.0;
-
-  // Bottom-left corner
-  corners[2].x = x + (cos_yaw * -half_width - sin_yaw * -half_height);
-  corners[2].y = y + (sin_yaw * -half_width + cos_yaw * -half_height);
-  corners[2].z = 0.0;
-
-  // Bottom-right corner
-  corners[3].x = x + (cos_yaw * half_width - sin_yaw * -half_height);
-  corners[3].y = y + (sin_yaw * half_width + cos_yaw * -half_height);
-  corners[3].z = 0.0;
-
-  // Close the rectangle
-  corners[4] = corners[0];
-
-  // Add corners to the marker
-  for (const auto & corner : corners) {
-    marker.points.push_back(corner);
-  }
-
+  
   return marker;
 }
 

--- a/include/slam_toolbox/visualization_utils.hpp
+++ b/include/slam_toolbox/visualization_utils.hpp
@@ -140,6 +140,74 @@ inline void toNavMap(
   }
 }
 
+inline visualization_msgs::msg::Marker toRectangleMarker(
+  const std::string & frame,
+  const std::string & ns,
+  const double & x,
+  const double & y,
+  const double & yaw,
+  const double & width,
+  const double & height,
+  const double & scale,
+  const std::array<double, 4> & color,  // RGBA array
+  rclcpp::Node::SharedPtr node)
+{
+  visualization_msgs::msg::Marker marker;
+
+  // Set header and metadata
+  marker.header.frame_id = frame;
+  marker.header.stamp = node->now();
+  marker.ns = ns;
+  marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+  marker.action = visualization_msgs::msg::Marker::ADD;
+  marker.pose.orientation.w = 1.0;
+
+  marker.scale.x = scale;  // Line width
+  marker.color.r = color[0];
+  marker.color.g = color[1];
+  marker.color.b = color[2];
+  marker.color.a = color[3];
+
+  // Calculate rectangle corners
+  double half_width = width / 2.0;
+  double half_height = height / 2.0;
+
+  double cos_yaw = cos(yaw);
+  double sin_yaw = sin(yaw);
+
+  std::vector<geometry_msgs::msg::Point> corners(5);
+
+  // Top-right corner
+  corners[0].x = x + (cos_yaw * half_width - sin_yaw * half_height);
+  corners[0].y = y + (sin_yaw * half_width + cos_yaw * half_height);
+  corners[0].z = 0.0;
+
+  // Top-left corner
+  corners[1].x = x + (cos_yaw * -half_width - sin_yaw * half_height);
+  corners[1].y = y + (sin_yaw * -half_width + cos_yaw * half_height);
+  corners[1].z = 0.0;
+
+  // Bottom-left corner
+  corners[2].x = x + (cos_yaw * -half_width - sin_yaw * -half_height);
+  corners[2].y = y + (sin_yaw * -half_width + cos_yaw * -half_height);
+  corners[2].z = 0.0;
+
+  // Bottom-right corner
+  corners[3].x = x + (cos_yaw * half_width - sin_yaw * -half_height);
+  corners[3].y = y + (sin_yaw * half_width + cos_yaw * -half_height);
+  corners[3].z = 0.0;
+
+  // Close the rectangle
+  corners[4] = corners[0];
+
+  // Add corners to the marker
+  for (const auto & corner : corners) {
+    marker.points.push_back(corner);
+  }
+
+  return marker;
+}
+
 }  // namespace vis_utils
 
 #endif  // SLAM_TOOLBOX__VISUALIZATION_UTILS_HPP_

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -1659,6 +1659,12 @@ public:
   void AddScan(LocalizedRangeScan * pScan);
 
   /**
+   * Add table which is founded position of scan 
+   * @param pScan
+   */
+  void AddTable(LocalizedRangeScan * pScan); 
+
+  /**
    * Adds scan to running scans of device that recorded scan
    * @param pScan
    */
@@ -1979,6 +1985,29 @@ public:
   std::shared_ptr<LocalizationInfos> GetBestResponse() const;
   void SetBestResponse(const std::shared_ptr<LocalizationInfos>& response);
 
+  std::vector<LocalizedRangeScan*> pScanVector;
+  kt_bool saveTableData_;
+
+  void StartTableStorage(kt_bool saveTableData);
+
+  void StoreAddress(LocalizedRangeScan* pScan) {
+      pScanVector.push_back(pScan);
+      std::cout << "Stored pScan at address: " << static_cast<void*>(pScan)
+                << " at index: " << pScanVector.size() - 1 << std::endl;
+  }
+
+  void AccessByIndex(size_t index) {
+      if (index < pScanVector.size()) {
+          LocalizedRangeScan* pScan = pScanVector[index];
+          std::cout << "Accessing pScan at address: " << static_cast<void*>(pScan)
+                    << " with pose: "
+                    << pScan->GetOdometricPose().GetX() << " "
+                    << pScan->GetOdometricPose().GetY() << " "
+                    << pScan->GetOdometricPose().GetHeading() << std::endl;
+      } else {
+          std::cout << "Index out of bounds!" << std::endl;
+      }
+  }
 
   /**
    * Allocate memory needed for mapping

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -2001,12 +2001,12 @@ public:
   };
 
   std::vector<TablePose> poseVector;
-  kt_bool saveTableData_;
+  kt_bool saveTableData_{false};
 
   void StartTableStorage(kt_bool saveTableData);
   void StorePose(const LocalizedRangeScan* pScan);
   void UpdateStoredPoses();
-  bool tableSaveComplete_ = false;
+  bool tableSaveComplete_{false};
 
   // void updatedTableData(LocalizedRangeScan* pScan);
   

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -2007,8 +2007,6 @@ public:
   void StorePose(const LocalizedRangeScan* pScan);
   void UpdateStoredPoses();
   bool tableSaveComplete_{false};
-
-  // void updatedTableData(LocalizedRangeScan* pScan);
   
   /**
    * Allocate memory needed for mapping

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -1993,17 +1993,14 @@ public:
       double y;
       double yaw;
       kt_int32u scanId;
-  };
-  enum class ProcessStatus {
-      Success,         
-      TableSaved,      
-      Failed           
+      std::string targetName;
   };
 
   std::vector<TablePose> poseVector;
   kt_bool saveTableData_{false};
-
-  void StartTableStorage(kt_bool saveTableData);
+  std::string saveTargetName_ = "masa_0";
+  kt_bool tableVectorUpdated_{false};
+  void StartTableStorage(kt_bool saveTableData, const std::string & saveTargetName);
   void StorePose(const LocalizedRangeScan* pScan);
   void UpdateStoredPoses();
   bool tableSaveComplete_{false};

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -1985,30 +1985,31 @@ public:
   std::shared_ptr<LocalizationInfos> GetBestResponse() const;
   void SetBestResponse(const std::shared_ptr<LocalizationInfos>& response);
 
-  std::vector<LocalizedRangeScan*> pScanVector;
+  /** 
+   * its for saving the desired pose of the robot
+   */
+  struct TablePose {
+      double x;
+      double y;
+      double yaw;
+      kt_int32u scanId;
+  };
+  enum class ProcessStatus {
+      Success,         
+      TableSaved,      
+      Failed           
+  };
+
+  std::vector<TablePose> poseVector;
   kt_bool saveTableData_;
 
   void StartTableStorage(kt_bool saveTableData);
+  void StorePose(const LocalizedRangeScan* pScan);
+  void UpdateStoredPoses();
+  bool tableSaveComplete_ = false;
 
-  void StoreAddress(LocalizedRangeScan* pScan) {
-      pScanVector.push_back(pScan);
-      std::cout << "Stored pScan at address: " << static_cast<void*>(pScan)
-                << " at index: " << pScanVector.size() - 1 << std::endl;
-  }
-
-  void AccessByIndex(size_t index) {
-      if (index < pScanVector.size()) {
-          LocalizedRangeScan* pScan = pScanVector[index];
-          std::cout << "Accessing pScan at address: " << static_cast<void*>(pScan)
-                    << " with pose: "
-                    << pScan->GetOdometricPose().GetX() << " "
-                    << pScan->GetOdometricPose().GetY() << " "
-                    << pScan->GetOdometricPose().GetHeading() << std::endl;
-      } else {
-          std::cout << "Index out of bounds!" << std::endl;
-      }
-  }
-
+  // void updatedTableData(LocalizedRangeScan* pScan);
+  
   /**
    * Allocate memory needed for mapping
    * @param rangeThreshold

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -3571,9 +3571,9 @@ void Mapper::SetBestResponse(const std::shared_ptr<Mapper::LocalizationInfos>& r
 void Mapper::StorePose(const LocalizedRangeScan * pScan)
 {
     TablePose pose; 
-    pose.x = pScan->GetOdometricPose().GetX();
-    pose.y = pScan->GetOdometricPose().GetY();
-    pose.yaw = pScan->GetOdometricPose().GetHeading();
+    pose.x = pScan->GetCorrectedPose().GetX();
+    pose.y = pScan->GetCorrectedPose().GetY();
+    pose.yaw = pScan->GetCorrectedPose().GetHeading();
     pose.scanId = pScan->GetStateId();
     poseVector.push_back(pose);
     std::cout << "Stored Pose: x=" << pose.x

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -1113,25 +1113,16 @@ void ScanMatcher::AddScan(
 
 #ifdef KARTO_DEBUG
   if (!validPoints.empty()) {
-    std::cout <<"validPoints is representing added points from chain" << std::endl;
+    std::cout << "validPoints is representing added points from chain" << std::endl;
+
+    // Print the first valid point's coordinates and address
     std::cout << "validPoints: (" << validPoints.begin()->GetX() << ", "
-              << validPoints.begin()->GetY() << ")" << std::endl;
+              << validPoints.begin()->GetY() << ") at address: " << &(*validPoints.begin()) << std::endl;
+
   } else {
     std::cout << "validPoints is empty!" << std::endl;
   }
 #endif
-
-  // if (!validPoints.empty()) {
-  //   std::cout << "validPoints is representing added points from chain" << std::endl;
-
-  //   // Print the first valid point's coordinates and address
-  //   std::cout << "validPoints: (" << validPoints.begin()->GetX() << ", "
-  //             << validPoints.begin()->GetY() << ") at address: " << &(*validPoints.begin()) << std::endl;
-
-
-  // } else {
-  //   std::cout << "validPoints is empty!" << std::endl;
-  // }
 
   // put in all valid points
   const_forEach(PointVectorDouble, &validPoints)
@@ -2210,24 +2201,11 @@ void MapperGraph::CorrectPoses()
 #endif
     const_forEach(ScanSolver::IdPoseVector, &pSolver->GetCorrections())
     {
-      std::cout << "\n\nProcessing correction for ID: " << iter->first << std::endl;
       LocalizedRangeScan * scan = m_pMapper->m_pMapperSensorManager->GetScan(iter->first);
       if (scan == NULL) {
         continue;
       }
-      // Print the corrected pose (iter->second)
-      std::cout << "Corrected Pose: X=" << iter->second.GetX()
-                << " Y=" << iter->second.GetY()
-                << " Heading=" << iter->second.GetHeading() << std::endl;
-
-      scan->SetCorrectedPoseAndUpdate(iter->second);
-    
-      std::cout << "Updated Scan Pose: X=" << scan->GetCorrectedPose().GetX()
-                << " Y=" << scan->GetCorrectedPose().GetY()
-                << " Heading=" << scan->GetCorrectedPose().GetHeading() << std::endl;
-      std::cout << "Scan object address: " << scan << std::endl;
-      std::cout << "Corrected Pose Address: " << &iter->second << "\n\n" << std::endl;
-
+      scan->SetCorrectedPoseAndUpdate(iter->second); 
     }
     pSolver->Clear();
   }
@@ -2961,17 +2939,11 @@ kt_bool Mapper::Process(LocalizedRangeScan * pScan, Matrix3 * covariance)
     m_pMapperSensorManager->AddScan(pScan);
 
     if (saveTableData_ == true) {
-      
+      std::cout << "\n\nStoreTablePose function has been called\n";
       StorePose(pScan);
-      std::cout << "POse of the scan: " << pScan->GetOdometricPose().GetX() << " " << pScan->GetOdometricPose().GetY() <<
-                                    " " << pScan->GetOdometricPose().GetHeading() << std::endl;
-
       saveTableData_ = false;
     }
     
-    // m_pMapperTableManager->AddTable(pScan);
-    // AccessByIndex(pScan);
-
     if (m_pUseScanMatching->GetValue()) {
       // add to graph
 
@@ -2992,7 +2964,6 @@ kt_bool Mapper::Process(LocalizedRangeScan * pScan, Matrix3 * covariance)
     }
 
     m_pMapperSensorManager->SetLastScan(pScan);
-    std::cout <<"\n\nAddedScan is PRocess "<< pScan->GetOdometricPose().GetX() << " " << pScan->GetOdometricPose().GetY() << " " << pScan->GetOdometricPose().GetHeading() << std::endl;
 
     return true;
   }

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -2941,7 +2941,7 @@ kt_bool Mapper::Process(LocalizedRangeScan * pScan, Matrix3 * covariance)
     if (saveTableData_ == true) {
       std::cout << "\n\nStoreTablePose function has been called\n";
       StorePose(pScan);
-      saveTableData_ = false;
+      saveTableData_= false;
     }
     
     if (m_pUseScanMatching->GetValue()) {
@@ -3546,11 +3546,13 @@ void Mapper::StorePose(const LocalizedRangeScan * pScan)
     pose.y = pScan->GetCorrectedPose().GetY();
     pose.yaw = pScan->GetCorrectedPose().GetHeading();
     pose.scanId = pScan->GetStateId();
+    pose.targetName = saveTargetName_;
     poseVector.push_back(pose);
     std::cout << "Stored Pose: x=" << pose.x
               << ", y=" << pose.y
               << ", yaw=" << pose.yaw
-              << ", nScans=" << pose.scanId << std::endl;
+              << ", nScans=" << pose.scanId 
+              << ", targetName=" << pose.targetName << std::endl;
 }
 
 void Mapper::UpdateStoredPoses()
@@ -3572,11 +3574,13 @@ void Mapper::UpdateStoredPoses()
                   << ", Y=" << pose.y
                   << ", Yaw=" << pose.yaw << std::endl;
     }
+    tableVectorUpdated_ = true;
 }
 
-void Mapper::StartTableStorage(kt_bool saveTableData)
+void Mapper::StartTableStorage(kt_bool saveTableData, const std::string& saveTargetName)
 {
   saveTableData_ = saveTableData;
+  saveTargetName_ = saveTargetName;
 }
 
 void Mapper::SetScanSolver(ScanSolver * pScanOptimizer)

--- a/msgs/SavedTargetInfo.msg
+++ b/msgs/SavedTargetInfo.msg
@@ -1,0 +1,5 @@
+float64 x
+float64 y
+float64 yaw
+uint32 scan_id
+string target_uid

--- a/msgs/SavedTargetInfoArray.msg
+++ b/msgs/SavedTargetInfoArray.msg
@@ -1,0 +1,1 @@
+slam_toolbox/SavedTargetInfo[] targets

--- a/solvers/ceres_solver.cpp
+++ b/solvers/ceres_solver.cpp
@@ -25,37 +25,70 @@ CeresSolver::CeresSolver()
 void CeresSolver::Configure(rclcpp::Node::SharedPtr node)
 /*****************************************************************************/
 {
-  node_ = node;
+  logger_ = node->get_logger();
 
   std::string solver_type, preconditioner_type, dogleg_type,
     trust_strategy, loss_fn, mode;
-  solver_type = node->declare_parameter("ceres_linear_solver",
-      std::string("SPARSE_NORMAL_CHOLESKY"));
-  preconditioner_type = node->declare_parameter("ceres_preconditioner",
-      std::string("JACOBI"));
-  dogleg_type = node->declare_parameter("ceres_dogleg_type",
-      std::string("TRADITIONAL_DOGLEG"));
-  trust_strategy = node->declare_parameter("ceres_trust_strategy",
-      std::string("LM"));
-  loss_fn = node->declare_parameter("ceres_loss_function",
-      std::string("None"));
-  mode = node->declare_parameter("mode", std::string("mapping"));
+  if (!node->has_parameter("ceres_linear_solver")) {
+    node->declare_parameter(
+      "ceres_linear_solver",
+      rclcpp::ParameterValue(std::string("SPARSE_NORMAL_CHOLESKY")));
+  }
+  solver_type = node->get_parameter("ceres_linear_solver").as_string();
+
+  if (!node->has_parameter("ceres_preconditioner")) {
+    node->declare_parameter(
+      "ceres_preconditioner",
+      rclcpp::ParameterValue(std::string("JACOBI")));
+  }
+  preconditioner_type = node->get_parameter("ceres_preconditioner").as_string();
+
+  if (!node->has_parameter("ceres_dogleg_type")) {
+    node->declare_parameter(
+      "ceres_dogleg_type",
+      rclcpp::ParameterValue(std::string("TRADITIONAL_DOGLEG")));
+  }
+  dogleg_type = node->get_parameter("ceres_dogleg_type").as_string();
+
+  if (!node->has_parameter("ceres_trust_strategy")) {
+    node->declare_parameter(
+      "ceres_trust_strategy",
+      rclcpp::ParameterValue(std::string("LM")));
+  }
+  trust_strategy = node->get_parameter("ceres_trust_strategy").as_string();
+
+  if (!node->has_parameter("ceres_loss_function")) {
+    node->declare_parameter(
+      "ceres_loss_function",
+      rclcpp::ParameterValue(std::string("None")));
+  }
+  loss_fn = node->get_parameter("ceres_loss_function").as_string();
+
+  if (!node->has_parameter("mode")) {
+    node->declare_parameter(
+      "mode",
+      rclcpp::ParameterValue(std::string("mapping")));
+  }
+  mode = node->get_parameter("mode").as_string();
+
   debug_logging_ = node->get_parameter("debug_logging").as_bool();
 
   corrections_.clear();
   first_node_ = nodes_->end();
 
   // formulate problem
-  angle_local_parameterization_ = AngleLocalParameterization::Create();
+  angle_manifold_ = AngleManifold::Create();
 
   // choose loss function default squared loss (NULL)
   loss_function_ = NULL;
   if (loss_fn == "HuberLoss") {
-    RCLCPP_INFO(node_->get_logger(),
+    RCLCPP_INFO(
+      node->get_logger(),
       "CeresSolver: Using HuberLoss loss function.");
     loss_function_ = new ceres::HuberLoss(0.7);
   } else if (loss_fn == "CauchyLoss") {
-    RCLCPP_INFO(node_->get_logger(),
+    RCLCPP_INFO(
+      node->get_logger(),
       "CeresSolver: Using CauchyLoss loss function.");
     loss_function_ = new ceres::CauchyLoss(0.7);
   }
@@ -63,15 +96,18 @@ void CeresSolver::Configure(rclcpp::Node::SharedPtr node)
   // choose linear solver default CHOL
   options_.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;
   if (solver_type == "SPARSE_SCHUR") {
-    RCLCPP_INFO(node_->get_logger(),
+    RCLCPP_INFO(
+      node->get_logger(),
       "CeresSolver: Using SPARSE_SCHUR solver.");
     options_.linear_solver_type = ceres::SPARSE_SCHUR;
   } else if (solver_type == "ITERATIVE_SCHUR") {
-    RCLCPP_INFO(node_->get_logger(),
+    RCLCPP_INFO(
+      node->get_logger(),
       "CeresSolver: Using ITERATIVE_SCHUR solver.");
     options_.linear_solver_type = ceres::ITERATIVE_SCHUR;
   } else if (solver_type == "CGNR") {
-    RCLCPP_INFO(node_->get_logger(),
+    RCLCPP_INFO(
+      node->get_logger(),
       "CeresSolver: Using CGNR solver.");
     options_.linear_solver_type = ceres::CGNR;
   }
@@ -79,11 +115,13 @@ void CeresSolver::Configure(rclcpp::Node::SharedPtr node)
   // choose preconditioner default Jacobi
   options_.preconditioner_type = ceres::JACOBI;
   if (preconditioner_type == "IDENTITY") {
-    RCLCPP_INFO(node_->get_logger(),
+    RCLCPP_INFO(
+      node->get_logger(),
       "CeresSolver: Using IDENTITY preconditioner.");
     options_.preconditioner_type = ceres::IDENTITY;
   } else if (preconditioner_type == "SCHUR_JACOBI") {
-    RCLCPP_INFO(node_->get_logger(),
+    RCLCPP_INFO(
+      node->get_logger(),
       "CeresSolver: Using SCHUR_JACOBI preconditioner.");
     options_.preconditioner_type = ceres::SCHUR_JACOBI;
   }
@@ -99,7 +137,8 @@ void CeresSolver::Configure(rclcpp::Node::SharedPtr node)
   // choose trust region strategy default LM
   options_.trust_region_strategy_type = ceres::LEVENBERG_MARQUARDT;
   if (trust_strategy == "DOGLEG") {
-    RCLCPP_INFO(node_->get_logger(),
+    RCLCPP_INFO(
+      node->get_logger(),
       "CeresSolver: Using DOGLEG trust region strategy.");
     options_.trust_region_strategy_type = ceres::DOGLEG;
   }
@@ -108,7 +147,8 @@ void CeresSolver::Configure(rclcpp::Node::SharedPtr node)
   if (options_.trust_region_strategy_type == ceres::DOGLEG) {
     options_.dogleg_type = ceres::TRADITIONAL_DOGLEG;
     if (dogleg_type == "SUBSPACE_DOGLEG") {
-      RCLCPP_INFO(node_->get_logger(),
+      RCLCPP_INFO(
+        node->get_logger(),
         "CeresSolver: Using SUBSPACE_DOGLEG dogleg type.");
       options_.dogleg_type = ceres::SUBSPACE_DOGLEG;
     }
@@ -146,7 +186,7 @@ void CeresSolver::Configure(rclcpp::Node::SharedPtr node)
   }
 
   // we do not want the problem definition to own these objects, otherwise they get
-  // deleted along with the problem 
+  // deleted along with the problem
   options_problem_.loss_function_ownership = ceres::Ownership::DO_NOT_TAKE_OWNERSHIP;
 
   problem_ = new ceres::Problem(options_problem_);
@@ -177,7 +217,8 @@ void CeresSolver::Compute()
   boost::mutex::scoped_lock lock(nodes_mutex_);
 
   if (nodes_->size() == 0) {
-    RCLCPP_WARN(node_->get_logger(),
+    RCLCPP_WARN(
+      logger_,
       "CeresSolver: Ceres was called when there are no nodes."
       " This shouldn't happen.");
     return;
@@ -188,7 +229,8 @@ void CeresSolver::Compute()
       problem_->HasParameterBlock(&first_node_->second(0)) &&
       problem_->HasParameterBlock(&first_node_->second(1)) &&
       problem_->HasParameterBlock(&first_node_->second(2))) {
-    RCLCPP_DEBUG(node_->get_logger(),
+    RCLCPP_DEBUG(
+      logger_,
       "CeresSolver: Setting first node as a constant pose:"
       "%0.2f, %0.2f, %0.2f.", first_node_->second(0),
       first_node_->second(1), first_node_->second(2));
@@ -205,7 +247,8 @@ void CeresSolver::Compute()
   }
 
   if (!summary.IsSolutionUsable()) {
-    RCLCPP_WARN(node_->get_logger(), "CeresSolver: "
+    RCLCPP_WARN(
+      logger_, "CeresSolver: "
       "Ceres could not find a usable solution to optimize.");
     return;
   }
@@ -267,7 +310,7 @@ void CeresSolver::Reset()
   problem_ = new ceres::Problem(options_problem_);
   first_node_ = nodes_->end();
 
-  angle_local_parameterization_ = AngleLocalParameterization::Create();
+  angle_manifold_ = AngleManifold::Create();
 }
 
 /*****************************************************************************/
@@ -311,7 +354,8 @@ void CeresSolver::AddConstraint(karto::Edge<karto::LocalizedRangeScan> * pEdge)
   if (node1it == nodes_->end() ||
     node2it == nodes_->end() || node1it == node2it)
   {
-    RCLCPP_WARN(node_->get_logger(),
+    RCLCPP_WARN(
+      logger_,
       "CeresSolver: Failed to add constraint, could not find nodes.");
     return;
   }
@@ -338,10 +382,10 @@ void CeresSolver::AddConstraint(karto::Edge<karto::LocalizedRangeScan> * pEdge)
     cost_function, loss_function_,
     &node1it->second(0), &node1it->second(1), &node1it->second(2),
     &node2it->second(0), &node2it->second(1), &node2it->second(2));
-  problem_->SetParameterization(&node1it->second(2),
-    angle_local_parameterization_);
-  problem_->SetParameterization(&node2it->second(2),
-    angle_local_parameterization_);
+  problem_->SetManifold(&node1it->second(2),
+    angle_manifold_);
+  problem_->SetManifold(&node2it->second(2),
+    angle_manifold_);
 
   blocks_->insert(std::pair<std::size_t, ceres::ResidualBlockId>(
       GetHash(node1, node2), block));
@@ -362,19 +406,20 @@ void CeresSolver::RemoveNode(kt_int32s id)
       problem_->RemoveParameterBlock(&nodeit->second(1));
       problem_->RemoveParameterBlock(&nodeit->second(2));
       RCLCPP_DEBUG(
-        node_->get_logger(),
+        logger_,
         "RemoveNode: Removed node id %d" ,nodeit->first);
     }
     else
     {
       RCLCPP_DEBUG(
-        node_->get_logger(),
+        logger_,
         "RemoveNode: Missing parameter blocks for "
         "node id %d", nodeit->first);
     }
     nodes_->erase(nodeit);
   } else {
-    RCLCPP_ERROR(node_->get_logger(), "RemoveNode: Failed to find node matching id %i",
+    RCLCPP_ERROR(
+      logger_, "RemoveNode: Failed to find node matching id %i",
       (int)id);
   }
 }
@@ -395,7 +440,8 @@ void CeresSolver::RemoveConstraint(kt_int32s sourceId, kt_int32s targetId)
     problem_->RemoveResidualBlock(it_b->second);
     blocks_->erase(it_b);
   } else {
-    RCLCPP_ERROR(node_->get_logger(),
+    RCLCPP_ERROR(
+      logger_,
       "RemoveConstraint: Failed to find residual block for %i %i",
       (int)sourceId, (int)targetId);
   }

--- a/solvers/ceres_solver.hpp
+++ b/solvers/ceres_solver.hpp
@@ -7,16 +7,17 @@
 #define SOLVERS__CERES_SOLVER_HPP_
 
 #include <math.h>
-#include <ceres/local_parameterization.h>
 #include <ceres/ceres.h>
 #include <vector>
 #include <unordered_map>
 #include <utility>
 #include <cmath>
+#include <memory>
 #include "karto_sdk/Mapper.h"
 #include "solvers/ceres_utils.h"
 
 #include "rclcpp/rclcpp.hpp"
+// #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "std_srvs/srv/empty.hpp"
 #include "slam_toolbox/toolbox_types.hpp"
 
@@ -38,6 +39,7 @@ public:
   virtual void Compute();  // Solve
   virtual void Clear();  // Resets the corrections
   virtual void Reset();  // Resets the solver plugin clean
+
   virtual void Configure(rclcpp::Node::SharedPtr node);
 
   // Adds a node to the solver
@@ -65,7 +67,7 @@ private:
   ceres::Problem::Options options_problem_;
   ceres::LossFunction * loss_function_;
   ceres::Problem * problem_;
-  ceres::LocalParameterization * angle_local_parameterization_;
+  ceres::Manifold * angle_manifold_;
   bool was_constant_set_, debug_logging_;
 
   // graph
@@ -75,7 +77,7 @@ private:
   boost::mutex nodes_mutex_;
 
   // ros
-  rclcpp::Node::SharedPtr node_;
+  rclcpp::Logger logger_{rclcpp::get_logger("CeresSolver")};
 };
 
 }  // namespace solver_plugins

--- a/src/loop_closure_assistant.cpp
+++ b/src/loop_closure_assistant.cpp
@@ -259,6 +259,23 @@ void LoopClosureAssistant::publishGraph()
   marray.markers.push_back(edges_marker);
   marray.markers.push_back(localization_edges_marker);
 
+  // Here is for 
+  const auto& localPoseVector = mapper_->poseVector;  
+  for (const auto& pose : localPoseVector) {
+    visualization_msgs::msg::Marker rectangle_marker =
+        vis_utils::toRectangleMarker(
+            "map",                   // Frame ID
+            "pose_visualization",    // Namespace
+            pose.x, pose.y, pose.yaw, // Pose: x, y, yaw
+            1.0, 0.1,                // Width and height of the rectangle
+            0.1,                     // Line width (scale)
+            {1.0, 0.0, 0.0, 1.0},    // Color: red (RGBA)
+            node_);                  // Node pointer
+
+    rectangle_marker.id = pose.scanId + 5000;  // Ensure unique IDs for these markers
+    marray.markers.push_back(rectangle_marker);
+  }
+
   // if disabled, clears out old markers
   interactive_server_->applyChanges();
   marker_publisher_->publish(marray);

--- a/src/slam_toolbox_localization.cpp
+++ b/src/slam_toolbox_localization.cpp
@@ -44,6 +44,9 @@ LocalizationSlamToolbox::LocalizationSlamToolbox(rclcpp::NodeOptions options)
     std::bind(&LocalizationSlamToolbox::set_parameters_callback, this,
     std::placeholders::_1, std::placeholders::_2));
 
+  marker_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
+      "slam_toolbox/table_vis", 10);
+
   // in localization mode, we cannot allow for interactive mode
   enable_interactive_mode_ = false;
 
@@ -249,7 +252,38 @@ void LocalizationSlamToolbox::triggerTableSave(){
     RCLCPP_INFO(get_logger(), "Triggering table save function");
     boost::mutex::scoped_lock lock(smapper_mutex_);
     smapper_->getMapper()->StartTableStorage(true);
+    // but its get the last data.
+    getSavedTableData();
+  }
+}
 
+void LocalizationSlamToolbox::getSavedTableData(){
+  if (processor_type_ == PROCESS){
+    RCLCPP_INFO(get_logger(), "Getting saved table data");
+    std::cout << "Pose vector size: " << smapper_->getMapper()->poseVector.size() << std::endl;
+    if (smapper_->getMapper()->poseVector.size() > 0) {
+      std::vector<karto::Mapper::TablePose>& localPoseVector = smapper_->getMapper()->poseVector;
+      visualization_msgs::msg::MarkerArray marker_array;
+      for (const auto& pose : localPoseVector) {
+          std::cout << "Pose ID: " << pose.scanId
+                    << ", X: " << pose.x
+                    << ", Y: " << pose.y
+                    << ", Yaw: " << pose.yaw << std::endl;
+          visualization_msgs::msg::Marker rectangle_marker =
+              vis_utils::toRectangleMarker(
+                  "map",                   // Frame ID
+                  "pose_visualization",    // Namespace
+                  pose.x, pose.y, pose.yaw, // Pose: x, y, yaw
+                  1.0, 0.1,                // Width and height of the rectangle
+                  0.1,                     // Line width (scale)
+                  {1.0, 0.0, 0.0, 1.0},    // Color: red (RGBA)
+                  shared_from_this());     // Node pointer
+
+          rectangle_marker.id = pose.scanId;
+          marker_array.markers.push_back(rectangle_marker);
+      }
+      marker_pub_->publish(marker_array);
+    }
   }
 }
 

--- a/src/slam_toolbox_localization.cpp
+++ b/src/slam_toolbox_localization.cpp
@@ -253,43 +253,41 @@ void LocalizationSlamToolbox::triggerTableSave(){
     boost::mutex::scoped_lock lock(smapper_mutex_);
     smapper_->getMapper()->StartTableStorage(true);
     // but its get the last data.
-    getSavedTableData();
+    // getSavedTableData();
   }
 }
 
-void LocalizationSlamToolbox::getSavedTableData() {
-  if (processor_type_ == PROCESS) {
-    RCLCPP_INFO(get_logger(), "Getting saved table data");
-    std::cout << "Pose vector size: " << smapper_->getMapper()->poseVector.size() << std::endl;
+// void LocalizationSlamToolbox::getSavedTableData() {
+//   if (processor_type_ == PROCESS) {
+//     RCLCPP_INFO(get_logger(), "Getting saved table data");
+//     std::cout << "Pose vector size: " << smapper_->getMapper()->poseVector.size() << std::endl;
+//     std::cout <<" map frame" << map_frame_ << std::endl;
 
-    if (smapper_->getMapper()->poseVector.size() > 0) {
-      const std::vector<karto::Mapper::TablePose>& localPoseVector = smapper_->getMapper()->poseVector;
-      visualization_msgs::msg::MarkerArray marker_array;
+//     if (smapper_->getMapper()->poseVector.size() > 0) {
+//       std::vector<karto::Mapper::TablePose>& localPoseVector = smapper_->getMapper()->poseVector;
+//       visualization_msgs::msg::MarkerArray marker_array;
+//       for (const auto& pose : localPoseVector) {
+//           std::cout << "Pose ID: " << pose.scanId
+//                     << ", X: " << pose.x
+//                     << ", Y: " << pose.y
+//                     << ", Yaw: " << pose.yaw << std::endl;
+//           visualization_msgs::msg::Marker rectangle_marker =
+//               vis_utils::toRectangleMarker(
+//                   "map",                   // Frame ID
+//                   "pose_visualization",    // Namespace
+//                   pose.x, pose.y, pose.yaw, // Pose: x, y, yaw
+//                   1.0, 0.1,                // Width and height of the rectangle
+//                   0.1,                     // Line width (scale)
+//                   {1.0, 0.0, 0.0, 1.0},    // Color: red (RGBA)
+//                   shared_from_this());     // Node pointer
 
-      for (const auto& pose : localPoseVector) {
-        std::cout << "Pose ID: " << pose.scanId
-                  << ", X: " << pose.x
-                  << ", Y: " << pose.y
-                  << ", Yaw: " << pose.yaw << std::endl;
-
-        // Create a sphere marker for the pose
-        visualization_msgs::msg::Marker sphere_marker =
-            vis_utils::toSphereMarker(
-                "map",                   // Frame ID
-                "pose_visualization",    // Namespace
-                pose.x, pose.y, pose.yaw, // Position (yaw not visualized in a sphere)
-                0.2,                     // Scale (sphere radius)
-                {0.0, 1.0, 0.0, 1.0},    // Color: green (RGBA)
-                shared_from_this());     // Node pointer
-
-        sphere_marker.id = pose.scanId; // Assign unique ID to avoid marker conflicts
-        marker_array.markers.push_back(sphere_marker);
-      }
-
-      marker_pub_->publish(marker_array);
-    }
-  }
-}
+//           rectangle_marker.id = pose.scanId;
+//           marker_array.markers.push_back(rectangle_marker);
+//       }
+//       marker_pub_->publish(marker_array);
+//     }
+//   }
+// }
 
 void LocalizationSlamToolbox::set_parameters_callback(
     const std::shared_ptr<slam_toolbox::srv::SetParametersService::Request> request,

--- a/src/slam_toolbox_localization.cpp
+++ b/src/slam_toolbox_localization.cpp
@@ -257,31 +257,35 @@ void LocalizationSlamToolbox::triggerTableSave(){
   }
 }
 
-void LocalizationSlamToolbox::getSavedTableData(){
-  if (processor_type_ == PROCESS){
+void LocalizationSlamToolbox::getSavedTableData() {
+  if (processor_type_ == PROCESS) {
     RCLCPP_INFO(get_logger(), "Getting saved table data");
     std::cout << "Pose vector size: " << smapper_->getMapper()->poseVector.size() << std::endl;
-    if (smapper_->getMapper()->poseVector.size() > 0) {
-      std::vector<karto::Mapper::TablePose>& localPoseVector = smapper_->getMapper()->poseVector;
-      visualization_msgs::msg::MarkerArray marker_array;
-      for (const auto& pose : localPoseVector) {
-          std::cout << "Pose ID: " << pose.scanId
-                    << ", X: " << pose.x
-                    << ", Y: " << pose.y
-                    << ", Yaw: " << pose.yaw << std::endl;
-          visualization_msgs::msg::Marker rectangle_marker =
-              vis_utils::toRectangleMarker(
-                  "map",                   // Frame ID
-                  "pose_visualization",    // Namespace
-                  pose.x, pose.y, pose.yaw, // Pose: x, y, yaw
-                  1.0, 0.1,                // Width and height of the rectangle
-                  0.1,                     // Line width (scale)
-                  {1.0, 0.0, 0.0, 1.0},    // Color: red (RGBA)
-                  shared_from_this());     // Node pointer
 
-          rectangle_marker.id = pose.scanId;
-          marker_array.markers.push_back(rectangle_marker);
+    if (smapper_->getMapper()->poseVector.size() > 0) {
+      const std::vector<karto::Mapper::TablePose>& localPoseVector = smapper_->getMapper()->poseVector;
+      visualization_msgs::msg::MarkerArray marker_array;
+
+      for (const auto& pose : localPoseVector) {
+        std::cout << "Pose ID: " << pose.scanId
+                  << ", X: " << pose.x
+                  << ", Y: " << pose.y
+                  << ", Yaw: " << pose.yaw << std::endl;
+
+        // Create a sphere marker for the pose
+        visualization_msgs::msg::Marker sphere_marker =
+            vis_utils::toSphereMarker(
+                "map",                   // Frame ID
+                "pose_visualization",    // Namespace
+                pose.x, pose.y, pose.yaw, // Position (yaw not visualized in a sphere)
+                0.2,                     // Scale (sphere radius)
+                {0.0, 1.0, 0.0, 1.0},    // Color: green (RGBA)
+                shared_from_this());     // Node pointer
+
+        sphere_marker.id = pose.scanId; // Assign unique ID to avoid marker conflicts
+        marker_array.markers.push_back(sphere_marker);
       }
+
       marker_pub_->publish(marker_array);
     }
   }

--- a/src/slam_toolbox_localization.cpp
+++ b/src/slam_toolbox_localization.cpp
@@ -252,42 +252,9 @@ void LocalizationSlamToolbox::triggerTableSave(){
     RCLCPP_INFO(get_logger(), "Triggering table save function");
     boost::mutex::scoped_lock lock(smapper_mutex_);
     smapper_->getMapper()->StartTableStorage(true);
-    // but its get the last data.
-    // getSavedTableData();
+
   }
 }
-
-// void LocalizationSlamToolbox::getSavedTableData() {
-//   if (processor_type_ == PROCESS) {
-//     RCLCPP_INFO(get_logger(), "Getting saved table data");
-//     std::cout << "Pose vector size: " << smapper_->getMapper()->poseVector.size() << std::endl;
-//     std::cout <<" map frame" << map_frame_ << std::endl;
-
-//     if (smapper_->getMapper()->poseVector.size() > 0) {
-//       std::vector<karto::Mapper::TablePose>& localPoseVector = smapper_->getMapper()->poseVector;
-//       visualization_msgs::msg::MarkerArray marker_array;
-//       for (const auto& pose : localPoseVector) {
-//           std::cout << "Pose ID: " << pose.scanId
-//                     << ", X: " << pose.x
-//                     << ", Y: " << pose.y
-//                     << ", Yaw: " << pose.yaw << std::endl;
-//           visualization_msgs::msg::Marker rectangle_marker =
-//               vis_utils::toRectangleMarker(
-//                   "map",                   // Frame ID
-//                   "pose_visualization",    // Namespace
-//                   pose.x, pose.y, pose.yaw, // Pose: x, y, yaw
-//                   1.0, 0.1,                // Width and height of the rectangle
-//                   0.1,                     // Line width (scale)
-//                   {1.0, 0.0, 0.0, 1.0},    // Color: red (RGBA)
-//                   shared_from_this());     // Node pointer
-
-//           rectangle_marker.id = pose.scanId;
-//           marker_array.markers.push_back(rectangle_marker);
-//       }
-//       marker_pub_->publish(marker_array);
-//     }
-//   }
-// }
 
 void LocalizationSlamToolbox::set_parameters_callback(
     const std::shared_ptr<slam_toolbox::srv::SetParametersService::Request> request,

--- a/srvs/ElevatorMode.srv
+++ b/srvs/ElevatorMode.srv
@@ -1,0 +1,9 @@
+bool inside_elev_zone 
+
+---
+
+string message
+bool success
+
+
+

--- a/srvs/SetParametersService.srv
+++ b/srvs/SetParametersService.srv
@@ -1,7 +1,7 @@
 string[] param_names
 float64[] param_values
 bool default_mode
-
+bool table_save_mode
 ---
 
 bool success

--- a/srvs/SetParametersService.srv
+++ b/srvs/SetParametersService.srv
@@ -2,6 +2,9 @@ string[] param_names
 float64[] param_values
 bool default_mode
 bool table_save_mode
+bool target_list_off
+string target_uid
+
 ---
 
 bool success


### PR DESCRIPTION
this version includes table mode with ceres2.2.0

for able to use those modes are must to have [robot_mission_controller](https://github.com/saha-robotics/robot_mission_controller/pull/318) and [robot_common](https://github.com/saha-robotics/robot_common/pull/460)  pr's


the logic of working:
While robot is moving we do bypass of 
https://github.com/Renbago/slam_toolbox/blob/humble-tableMode-ceres.2.2.0/lib/karto_sdk/src/Mapper.cpp#L2929-L2931
the current scan data and save in different vector also adding to posegraph. later then if any loopclosure happened and the poses are corrected:
https://github.com/Renbago/slam_toolbox/blob/6be5ea44a0c1fc0d761ece06aaed2071574c0d6e/lib/karto_sdk/src/Mapper.cpp#L2202C1-L2236C2
we are calling the ```   m_pMapper->UpdateStoredPoses(); ``` and updating the uid's. 
