### PR TITLE
feat:dynamic param change

### DIFF
--- a/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/include/slam_toolbox/slam_toolbox_common.hpp
@@ -30,6 +30,7 @@
 #include <fstream>
 
 #include "rclcpp/rclcpp.hpp"
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
 #include "message_filters/subscriber.h"
 #include "tf2_ros/transform_broadcaster.h"
 #include "tf2_ros/transform_listener.h"
@@ -92,6 +93,8 @@ protected:
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<slam_toolbox::srv::DeserializePoseGraph::Request> req,
     std::shared_ptr<slam_toolbox::srv::DeserializePoseGraph::Response> resp);
+  rcl_interfaces::msg::SetParametersResult parametersCallback(
+      const std::vector<rclcpp::Parameter> &parameters);
 
   // Loaders
   void loadSerializedPoseGraph(std::unique_ptr<karto::Mapper> &, std::unique_ptr<karto::Dataset> &);
@@ -144,6 +147,7 @@ protected:
   std::shared_ptr<rclcpp::Service<slam_toolbox::srv::Pause>> ssPauseMeasurements_;
   std::shared_ptr<rclcpp::Service<slam_toolbox::srv::SerializePoseGraph>> ssSerialize_;
   std::shared_ptr<rclcpp::Service<slam_toolbox::srv::DeserializePoseGraph>> ssDesserialize_;
+  OnSetParametersCallbackHandle::SharedPtr callback_handle_;
 
   // Storage for ROS parameters
   std::string odom_frame_, map_frame_, base_frame_, map_name_, scan_topic_;


### PR DESCRIPTION
This pull request introduces a new callback for handling parameter updates in the `SlamToolbox` class. The changes include adding necessary includes, defining the callback method, and registering the callback in the `setROSInterfaces` method.

Key changes:

* **Include necessary headers:**
  * Added `#include "rcl_interfaces/msg/set_parameters_result.hpp"` to `include/slam_toolbox/slam_toolbox_common.hpp`.

* **Define the callback method:**
  * Added `parametersCallback` method to the `SlamToolbox` class in `include/slam_toolbox/slam_toolbox_common.hpp`.
  * Implemented `parametersCallback` method in `src/slam_toolbox_common.cpp`. This method updates various parameters and logs the changes.

* **Register the callback:**
  * Added `callback_handle_` member to the `SlamToolbox` class in `include/slam_toolbox/slam_toolbox_common.hpp`.
  * Registered the `parametersCallback` in the `setROSInterfaces` method in `src/slam_toolbox_common.cpp`.